### PR TITLE
Optimize Dockerfiles for smaller image size and better performance

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm
+FROM python:3.12-slim-bookworm AS base
 
 ARG APP_HOME=/usr/src/app
 WORKDIR ${APP_HOME}
@@ -13,24 +13,24 @@ ENV PYTHONDONTWRITEBYTECODE 1 \
 ENV PATH="$POETRY_HOME/bin:$PATH"
 
 RUN apt update \
-  && apt install -y curl git libpq-dev gcc libglu1 \
-  && pip install --upgrade pip \
-  && pip install psycopg psycopg-binary \
+  && apt install -y --no-install-recommends curl git libpq-dev gcc libglu1 \
+  && pip install --no-cache-dir --upgrade pip \
+  && pip install --no-cache-dir psycopg psycopg-binary \
   && curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr/local/poetry python3 - \
-  # cleaning up unused files
   && apt purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*
 
 COPY ./pyproject.toml ${APP_HOME}/
 
 RUN poetry config virtualenvs.create false \
-  && poetry install
+  && poetry install --no-root --no-interaction --no-ansi
+
+FROM base AS final
 
 COPY ./docker/django/entrypoint /usr/src/app/docker/django/entrypoint
 COPY ./docker/django/start_dev /usr/src/app/docker/django/start_dev
 
-RUN ls -la /usr/src/app/docker/django/ \
-  && chmod +x /usr/src/app/docker/django/start_dev \
+RUN chmod +x /usr/src/app/docker/django/start_dev \
   && sed -i 's/\r$//g' /usr/src/app/docker/django/start_dev
 
 COPY . ${APP_HOME}/

--- a/docker/django/Dockerfile.prod
+++ b/docker/django/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm
+FROM python:3.12-slim-bookworm AS base
 
 ARG APP_HOME=/usr/src/app
 WORKDIR ${APP_HOME}
@@ -13,26 +13,24 @@ ENV PYTHONDONTWRITEBYTECODE 1 \
 ENV PATH="$POETRY_HOME/bin:$PATH"
 
 RUN apt update \
-  && apt install -y curl git libpq-dev gcc libglu1 libpq5 \
-  && pip install --upgrade pip \
-  && pip install psycopg psycopg-binary \
-  && pip install "psycopg[c]" \
-  && pip install gunicorn \
+  && apt install -y --no-install-recommends curl git libpq-dev gcc libglu1 libpq5 \
+  && pip install --no-cache-dir --upgrade pip \
+  && pip install --no-cache-dir psycopg psycopg-binary "psycopg[c]" gunicorn \
   && curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr/local/poetry python3 - \
-  # cleaning up unused files
   && apt purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*
 
 COPY ./pyproject.toml ${APP_HOME}/
 
 RUN poetry config virtualenvs.create false \
-  && poetry install
+  && poetry install --no-root --no-interaction --no-ansi
+
+FROM base AS final
 
 COPY ./docker/django/entrypoint_prod /usr/src/app/docker/django/entrypoint_prod
 COPY ./docker/django/start_production /usr/src/app/docker/django/start_production
 
-RUN ls -la /usr/src/app/docker/django/ \
-  && chmod +x /usr/src/app/docker/django/start_production \
+RUN chmod +x /usr/src/app/docker/django/start_production \
   && sed -i 's/\r$//g' /usr/src/app/docker/django/start_production
 
 COPY . ${APP_HOME}/


### PR DESCRIPTION
This PR will:

- Use specific version tags for base images
- Combine multiple RUN instructions to reduce layers
- Use `--no-cache-dir` flag with pip install
- Apply multi-stage builds to separate build and runtime dependencies
- Use `--no-install-recommends` flag with apt install
- Optimize poetry install with `--no-root`, `--no-interaction`, and `--no-ansi` flags
- Remove unnecessary `ls -la` command in production Dockerfile